### PR TITLE
Add Vite setup for React app

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
+  "changelog": ["@changesets/changelog-github", {"repo": ""}],
+  "commit": false,
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.changeset/setup-vite-react-app.md
+++ b/.changeset/setup-vite-react-app.md
@@ -1,0 +1,5 @@
+---
+"@spfx/react-app": patch
+---
+
+Switch the React SPA to use Vite for development and building.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # spfx-react-template
-A test project to separate React component from SPFx project and then use it in SPFx project.
+
+This repository demonstrates a pnpm workspace managing three independent packages.
+
+## Packages
+
+- **react-app** – React 17 single page application scaffold with TypeScript 5 using Vite.
+- **sharepoint-lib** – TypeScript library wrapping PnPjs for SharePoint Online CRUD operations.
+- **spfx-project** – SPFx 1.21 project using React 17 and TypeScript 5.
+
+Changesets is configured for release management and each package maintains its own version.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "spfx-react-template-root",
+  "private": true,
+  "workspaces": ["packages/*"],
+  "devDependencies": {
+    "@changesets/cli": "^2.26.1"
+  },
+  "scripts": {
+    "changeset": "changeset",
+    "version-packages": "changeset version && pnpm install",
+    "release": "changeset publish"
+  }
+}

--- a/packages/react-app/README.md
+++ b/packages/react-app/README.md
@@ -1,0 +1,3 @@
+# React SPA
+
+This package contains a React 17 single page application using TypeScript 5 and Vite for development and bundling.

--- a/packages/react-app/index.html
+++ b/packages/react-app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@spfx/react-app",
+  "version": "0.1.0",
+  "private": false,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^3.1.0"
+  }
+}

--- a/packages/react-app/src/App.tsx
+++ b/packages/react-app/src/App.tsx
@@ -1,0 +1,3 @@
+export const App = () => {
+  return <div>Hello React 17</div>;
+};

--- a/packages/react-app/src/main.tsx
+++ b/packages/react-app/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { App } from './App';
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.getElementById('root')
+);

--- a/packages/react-app/tsconfig.json
+++ b/packages/react-app/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "target": "esnext",
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/packages/react-app/vite.config.ts
+++ b/packages/react-app/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/packages/sharepoint-lib/README.md
+++ b/packages/sharepoint-lib/README.md
@@ -1,0 +1,3 @@
+# SharePoint Online Library
+
+A TypeScript library that uses PnPjs to interact with SharePoint Online lists and libraries.

--- a/packages/sharepoint-lib/package.json
+++ b/packages/sharepoint-lib/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@spfx/sharepoint-lib",
+  "version": "0.1.0",
+  "private": false,
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "build": "echo 'build lib'"
+  },
+  "dependencies": {
+    "@pnp/sp": "^3.4.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/sharepoint-lib/src/index.ts
+++ b/packages/sharepoint-lib/src/index.ts
@@ -1,0 +1,3 @@
+export const placeholder = () => {
+  return 'SharePoint library';
+};

--- a/packages/sharepoint-lib/tsconfig.json
+++ b/packages/sharepoint-lib/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "module": "commonjs",
+    "target": "es2019",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/packages/spfx-project/README.md
+++ b/packages/spfx-project/README.md
@@ -1,0 +1,3 @@
+# SPFx Project
+
+A SharePoint Framework 1.21 project using React 17 and TypeScript 5.

--- a/packages/spfx-project/package.json
+++ b/packages/spfx-project/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@spfx/spfx-project",
+  "version": "0.1.0",
+  "private": false,
+  "scripts": {
+    "build": "gulp bundle",
+    "package-solution": "gulp package-solution"
+  },
+  "dependencies": {
+    "@microsoft/sp-core-library": "1.21.0",
+    "@microsoft/sp-webpart-base": "1.21.0",
+    "@microsoft/sp-lodash-subset": "1.21.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
+  },
+  "devDependencies": {
+    "@microsoft/rush-stack-compiler-5.0": "5.0.0",
+    "@types/react": "17.0.56",
+    "@types/react-dom": "17.0.17",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/spfx-project/src/webparts/myWebpart/MyWebpart.ts
+++ b/packages/spfx-project/src/webparts/myWebpart/MyWebpart.ts
@@ -1,0 +1,1 @@
+export class MyWebpart {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'


### PR DESCRIPTION
## Summary
- switch the React SPA to use Vite
- update tsconfig and README for the Vite-based SPA
- document Vite usage in root README
- record the change with a changeset

## Testing
- `pnpm -r build` *(fails: vite and gulp not found as dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68550d2324b483259c47d1054e5ae706