### PR TITLE
Add SharePoint helpers

### DIFF
--- a/packages/sharepoint-lib/README.md
+++ b/packages/sharepoint-lib/README.md
@@ -1,3 +1,11 @@
 # SharePoint Online Library
 
-A TypeScript library that uses PnPjs to interact with SharePoint Online lists and libraries.
+A TypeScript library that exposes helper functions for working with SharePoint Online
+via PnPjs. The library is authored as ES modules and can be consumed in modern
+TypeScript projects.
+
+## Features
+
+- **User helpers** – fetch the current user or query users by id or login name.
+- **List helpers** – simple CRUD helpers for SharePoint lists.
+- **Library helpers** – upload, download, update and delete files in document libraries.

--- a/packages/sharepoint-lib/package.json
+++ b/packages/sharepoint-lib/package.json
@@ -2,10 +2,11 @@
   "name": "@spfx/sharepoint-lib",
   "version": "0.1.0",
   "private": false,
+  "type": "module",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "echo 'build lib'"
+    "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
     "@pnp/sp": "^3.4.1"

--- a/packages/sharepoint-lib/src/index.ts
+++ b/packages/sharepoint-lib/src/index.ts
@@ -1,3 +1,111 @@
-export const placeholder = () => {
-  return 'SharePoint library';
+import { SPFI } from '@pnp/sp';
+import '@pnp/sp/webs';
+import '@pnp/sp/site-users/web';
+import '@pnp/sp/lists';
+import '@pnp/sp/items';
+import '@pnp/sp/files';
+import '@pnp/sp/folders';
+
+// User helpers
+export const getUserById = async (sp: SPFI, id: number) => {
+  return sp.web.siteUsers.getById(id)();
+};
+
+export const getUserByLoginName = async (sp: SPFI, loginName: string) => {
+  return sp.web.siteUsers.getByLoginName(loginName)();
+};
+
+export const getCurrentUser = async (sp: SPFI) => {
+  return sp.web.currentUser();
+};
+
+// List helpers
+export const addListItem = async (
+  sp: SPFI,
+  listTitle: string,
+  properties: Record<string, unknown>
+) => {
+  return sp.web.lists.getByTitle(listTitle).items.add(properties);
+};
+
+export const getListItems = async (
+  sp: SPFI,
+  listTitle: string,
+  select: string[] = [],
+  filter?: string
+) => {
+  let query = sp.web.lists.getByTitle(listTitle).items;
+
+  if (select.length) {
+    query = query.select(...select);
+  }
+
+  if (filter) {
+    query = query.filter(filter);
+  }
+
+  return query();
+};
+
+export const updateListItem = async (
+  sp: SPFI,
+  listTitle: string,
+  id: number,
+  properties: Record<string, unknown>
+) => {
+  return sp.web.lists.getByTitle(listTitle).items.getById(id).update(properties);
+};
+
+export const deleteListItem = async (
+  sp: SPFI,
+  listTitle: string,
+  id: number
+) => {
+  return sp.web.lists.getByTitle(listTitle).items.getById(id).delete();
+};
+
+// Library helpers
+export const uploadFile = async (
+  sp: SPFI,
+  libraryPath: string,
+  fileName: string,
+  content: Blob | ArrayBuffer
+) => {
+  return sp.web
+    .getFolderByServerRelativePath(libraryPath)
+    .files.add(fileName, content, true);
+};
+
+export const getFile = async (
+  sp: SPFI,
+  libraryPath: string,
+  fileName: string
+) => {
+  return sp.web
+    .getFolderByServerRelativePath(libraryPath)
+    .files.getByName(fileName)
+    .getBlob();
+};
+
+export const updateFile = async (
+  sp: SPFI,
+  libraryPath: string,
+  fileName: string,
+  content: Blob | ArrayBuffer
+) => {
+  return sp.web
+    .getFolderByServerRelativePath(libraryPath)
+    .files.getByName(fileName)
+    .setContent(content);
+};
+
+export const deleteFile = async (
+  sp: SPFI,
+  libraryPath: string,
+  fileName: string
+) => {
+  return sp.web
+    .getFolderByServerRelativePath(libraryPath)
+    .files.getByName(fileName)
+    .delete();
 };

--- a/packages/sharepoint-lib/tsconfig.json
+++ b/packages/sharepoint-lib/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "module": "commonjs",
-    "target": "es2019",
+    "module": "ES2020",
+    "target": "ES2020",
+    "moduleResolution": "node",
     "strict": true,
     "esModuleInterop": true,
     "outDir": "lib"


### PR DESCRIPTION
## Summary
- author sharepoint-lib as an ES module package
- implement user, list and file helpers for PnPjs
- document features

## Testing
- `pnpm --filter @spfx/sharepoint-lib build` *(fails: Cannot find module '@pnp/sp')*
- `pnpm install` *(fails: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_685512e53a9c8325bd23b693349933d0